### PR TITLE
Fix #1 Error when requesting D3 visualization

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -104,4 +104,4 @@ def d3():
 
 	meta_data = data.stats_ams_meta.to_json(orient='records')
 	return render_template("d3.html", data=plot_data, meta_data=meta_data,
-		x_variables=data.all_vars, area_names=data.area_names, selected_area_name=area_name)
+		x_variables=data.model_vars, area_names=data.area_names, selected_area_name=area_name)


### PR DESCRIPTION
Original file uses data.all_vars for the variables of the D3 visualization, which is not defined. Using data.model_vars does show a correct visualization.